### PR TITLE
_code-cov, _deploy + option repo overrides

### DIFF
--- a/.github/workflows/_code-cov.yml
+++ b/.github/workflows/_code-cov.yml
@@ -11,6 +11,11 @@ on:
         type: string
         required: true
         description: Relative path to lcov.info
+      repository:
+        type: string
+        default: ${{ github.repository }}
+        required: false
+        description: Optionally, specify a different repo to clone
       test_cmd:
         type: string
         required: true
@@ -26,6 +31,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.repository }}
 
       - name: Get npm cache directory
         id: npm-cache-dir

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -11,6 +11,11 @@ on:
         type: string
         required: true
         description: Replace existing objects/artifacts?
+      repository:
+        type: string
+        default: ${{ github.repository }}
+        required: false
+        description: Optionally, specify a different repo to clone
       template_file:
         type: string
         required: true
@@ -36,6 +41,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.repository }}
 
       - name: Deploy
         run: |


### PR DESCRIPTION
Add optional overrides for the repository being cloned. Particularly useful for testing the helpers using nr-quickstart-typescript.  Previously completed for _build, this PR does the same for _code-cov and _deploy.