### PR TITLE
GitHub Actions deprecating set-output command

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -65,7 +65,7 @@ jobs:
               if [[ "${check}" =~ "${t}" ]]
               then
                   # Output build=true for next steps
-                  echo "::set-output name=build::true"
+                  echo "build=true" >> $GITHUB_OUTPUT
                   echo -e "${t}\n --> ${check}\n"
                   exit 0
               fi
@@ -78,13 +78,13 @@ jobs:
           if [ $(curl -ILso /dev/null -w "%{http_code}" -H "Authorization: Bearer ${TOKEN}" "${URL}") -ne 200 ]
           then
               # Output build=true for next steps
-              echo "::set-output name=build::true"
+              echo "build=true" >> $GITHUB_OUTPUT
               echo -e "\nBuilding image, since no fallback is available!"
               exit 0
           fi
 
           # If at this point, no build is required
-          echo "::set-output name=build::false"
+          echo "build=false" >> $GITHUB_OUTPUT
           echo "Container build not required"
 
       # If a build is not required, reuse a previous image

--- a/.github/workflows/_code-cov.yml
+++ b/.github/workflows/_code-cov.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
 
       - name: Cache npm cache directory
         uses: actions/cache@v3

--- a/.github/workflows/_image_promote.yml
+++ b/.github/workflows/_image_promote.yml
@@ -68,7 +68,7 @@ jobs:
 
           # If different, then trigger updates
           if [[ "${SHA_PREV}" != "${SHA_ZONE}" ]]; then
-            echo "::set-output name=build::true"
+            echo "build=true" >> $GITHUB_OUTPUT
             echo "Image has changed"
 
             # Login to OpenShift and select project


### PR DESCRIPTION
Copied from issue #30:

---

Looks like GitHub Actions' set-output is being replaced. That's great, because I found it super clunky!

Blog link:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Deprecation warning:

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Run: (not permanent!)
https://github.com/bcgov/nr-quickstart-helpers/actions/runs/3325167762