### PR TITLE
Add replica vars (new in nr-...-typescript), reorder

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -57,6 +57,8 @@ jobs:
   builds:
     # These builds don't have triggers and will fire every time
     name: Builds
+    needs:
+      - builds-retag
     uses: ./.github/workflows/_build.yml
     strategy:
       matrix:
@@ -78,14 +80,13 @@ jobs:
     with:
       component: ${{ matrix.component }}
       repository: bcgov/nr-quickstart-typescript
-      test_cmd: npm run test:cov
+      test_cmd: npm run test
 
   deploys:
     name: Deploys
     needs:
       - builds
       - builds-retag
-      - tests
     # If any of the prerequs created a build, then deploy
     if: contains(needs.*.outputs.build, 'true')
     uses: ./.github/workflows/_deploy.yml
@@ -100,11 +101,17 @@ jobs:
           - component: backend
             overwrite: true
             template_file: backend/openshift.deploy.yml
-            template_vars: -p ZONE=${{ github.event.number }} -p PROMOTE=${{ github.repository }}/backend:${{ github.event.number }} -p NAME=${{ github.event.repository.name }}
+            template_vars:
+              -p ZONE=${{ github.event.number }} -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
+              -p PROMOTE=${{ github.repository }}/backend:${{ github.event.number }}
+              -p NAME=${{ github.event.repository.name }}
           - component: frontend
             overwrite: true
             template_file: frontend/openshift.deploy.yml
-            template_vars: -p ZONE=${{ github.event.number }} -p PROMOTE=${{ github.repository }}/frontend:${{ github.event.number }} -p NAME=${{ github.event.repository.name }}
+            template_vars:
+              -p ZONE=${{ github.event.number }} -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
+              -p PROMOTE=${{ github.repository }}/frontend:${{ github.event.number }}
+              -p NAME=${{ github.event.repository.name }}
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_server: ${{ secrets.OC_SERVER }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -86,7 +86,6 @@ jobs:
     name: Deploys
     needs:
       - builds
-      - builds-retag
     # If any of the prerequs created a build, then deploy
     if: contains(needs.*.outputs.build, 'true')
     uses: ./.github/workflows/_deploy.yml


### PR DESCRIPTION
nr-quickstart-typescript has added OpenShift template variables for the min and max number of replicas for horizontal scaling (thanks @mishraomp!).  This PR adds those vars.

Also, slight PR open workflow reordering.

<p>---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-helpers-63-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-helpers-63-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-helpers/actions/workflows/merge-main.yml)