### PR TITLE
_build permissions.package=write

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -41,6 +41,8 @@ jobs:
   build:
     name: ${{ inputs.component }}
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
     outputs:
       build: ${{ steps.check.outputs.build }}
     steps:


### PR DESCRIPTION
Inconsistent failures tagging/retagging on GHCR.io.  Setting package write permissions.