### PR TITLE
Bug: tnit template stopping workflow

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -90,7 +90,7 @@ jobs:
           fi
 
           # Follow any active rollouts (see deploymentconfigs)
-          oc rollout status dc/${DC} -w
+          [ -z "${DC}" ]|| oc rollout status dc/${DC} -w
 
       - name: Find Routes
         id: get-route


### PR DESCRIPTION
Bug.  Init template doesn't generate a deployment config, which is causing an error and stopping workflows.

<p>---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-helpers-72-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-helpers-72-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-helpers/actions/workflows/merge-main.yml)