### PR TITLE
Optional param for diff branch in _build

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -30,6 +30,11 @@ on:
         required: false
         default: "('.')"
         description: Paths used to trigger a build, e.g. ('./backend/', './frontend/)
+      upstream_branch:
+        type: string
+        required: false
+        default: ${{ env.default_branch }}
+        description: Branch to diff against
     secrets:
       gh_token:
         required: true
@@ -66,13 +71,13 @@ jobs:
           # Check out source repo
           repository: ${{ github.repository }}
 
-      # Check triggers to see if a build is required
-      # Returns jobs.check.outputs.build as a boolean (true/false)
+      # Check triggers to see if a build is required; always build if inputs.img_fallback not provided or doesn't exist
       - name: Check and process modified files
+        # Returns jobs.check.outputs.build as a boolean (true/false)
         id: check
         run: |
           # Fetch default branch to diff against
-          git fetch origin ${{ env.default_branch }}:refs/remotes/origin/main
+          git fetch origin ${{ inputs.upstream_branch }}
 
           # Trigger build if diff matches any triggers
           TRIGGERS=${{ inputs.triggers }}
@@ -87,7 +92,7 @@ jobs:
                   exit 0
               fi
             done
-          done < <(git diff origin/${{ env.default_branch }} --name-only)
+          done < <(git diff origin/${{ inputs.upstream_branch }} --name-only)
 
           # Check that fallback tag exists, otherwise build
           TOKEN=$(curl -s https://ghcr.io/token\?scope\="repository:${{ github.repository }}/${{ inputs.component }}:pull" | jq -r .token)

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -33,7 +33,7 @@ on:
       upstream_branch:
         type: string
         required: false
-        default: ${{ env.default_branch }}
+        default: ${{ github.event.repository.default_branch }}
         description: Branch to diff against
     secrets:
       gh_token:
@@ -43,9 +43,6 @@ on:
       build:
         description: True = build has changed
         value: ${{ jobs.build.outputs.build }}
-
-env:
-  default_branch: ${{ github.event.repository.default_branch }}
 
 jobs:
   secret-search:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -41,7 +41,7 @@ jobs:
           - component: backend
             triggers: ('backend/')
           - component: frontend
-            triggers: ('.')
+            triggers: ('frontend/')
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -41,7 +41,7 @@ jobs:
           - component: backend
             triggers: ('backend/')
           - component: frontend
-            triggers: ('frontend/')
+            triggers: ('.')
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:


### PR DESCRIPTION
Not everyone will compare triggers against the default branch.  Add an optional parameter for changing that.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-helpers-78-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-helpers-78-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-helpers/actions/workflows/merge-main.yml)