### PR TITLE
Make _deploy template_vars optional

### DIFF
--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -42,7 +42,8 @@ on:
         description: Template file (e.g. frontend/openshift.deploy.yml)
       template_vars:
         type: string
-        required: true
+        required: false
+        default: ""
         description: Template variables to pass (e.g. -p ZONE=...)
     secrets:
       oc_namespace:

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -28,19 +28,15 @@ jobs:
           - component: backend
             overwrite: true
             template_file: backend/openshift.deploy.yml
-            template_vars: ""
           - component: database
             overwrite: false
             template_file: database/openshift.deploy.yml
-            template_vars: ""
           - component: frontend
             overwrite: true
             template_file: frontend/openshift.deploy.yml
-            template_vars: ""
           - component: init
             overwrite: false
             template_file: common/openshift.init.yml
-            template_vars: ""
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_server: ${{ secrets.OC_SERVER }}
@@ -68,19 +64,15 @@ jobs:
           - component: backend
             overwrite: true
             template_file: backend/openshift.deploy.yml
-            template_vars: ""
           - component: database
             overwrite: false
             template_file: database/openshift.deploy.yml
-            template_vars: ""
           - component: frontend
             overwrite: true
             template_file: frontend/openshift.deploy.yml
-            template_vars: ""
           - component: init
             overwrite: false
             template_file: common/openshift.init.yml
-            template_vars: ""
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_server: ${{ secrets.OC_SERVER }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -88,7 +88,6 @@ jobs:
           - component: database
             overwrite: false
             template_file: database/openshift.deploy.yml
-            template_vars: ""
           - component: frontend
             overwrite: true
             template_file: frontend/openshift.deploy.yml
@@ -96,7 +95,6 @@ jobs:
           - component: init
             overwrite: false
             template_file: common/openshift.init.yml
-            template_vars: ""
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_server: ${{ secrets.OC_SERVER }}


### PR DESCRIPTION
There are cases where no template variables are needed, so this really should have been optional in the first place.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-helpers-86-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-helpers-86-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-helpers/actions/workflows/merge-main.yml)