### PR TITLE
New database container in nr-quickstart-typescript

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -78,11 +78,9 @@ jobs:
 
           # Trigger build if diff matches any triggers
           TRIGGERS=${{ inputs.triggers }}
-          while read -r check
-          do
+          while read -r check; do
             for t in "${TRIGGERS[@]}"; do
-              if [[ "${check}" =~ "${t}" ]]
-              then
+              if [[ "${check}" =~ "${t}" ]]; then
                   # Output build=true for next steps
                   echo "build=true" >> $GITHUB_OUTPUT
                   echo -e "${t}\n --> ${check}\n"

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -58,7 +58,7 @@ jobs:
         uses: Hacks4Snacks/secret-search@v1.1
 
   build:
-    name: ${{ inputs.component }}
+    name: Build
     runs-on: ubuntu-22.04
     outputs:
       build: ${{ steps.check.outputs.build }}

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -57,7 +57,7 @@ on:
 
 jobs:
   deploy:
-    name: ${{ inputs.component }}
+    name: Deploy
     runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
     steps:

--- a/.github/workflows/_image_promote.yml
+++ b/.github/workflows/_image_promote.yml
@@ -36,7 +36,7 @@ env:
 
 jobs:
   image-promote:
-    name: ${{ inputs.component }}
+    name: Promote
     runs-on: ubuntu-22.04
     environment: ${{ inputs.env_target }}
     steps:

--- a/.github/workflows/_unit-tests.yml
+++ b/.github/workflows/_unit-tests.yml
@@ -38,7 +38,7 @@ on:
 
 jobs:
   test:
-    name: ${{ inputs.dir }}
+    name: Test
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -28,15 +28,15 @@ jobs:
           - component: database
             overwrite: false
             template_file: database/openshift.deploy.yml
-            template_vars: -p ZONE=test -p NAME=${{ github.event.repository.name }}
+            template_vars: ""
           - component: backend
             overwrite: true
             template_file: backend/openshift.deploy.yml
-            template_vars: -p ZONE=test -p PROMOTE=${{ github.repository }}/backend:test -p NAME=${{ github.event.repository.name }}
+            template_vars: ""
           - component: frontend
             overwrite: true
             template_file: frontend/openshift.deploy.yml
-            template_vars: -p ZONE=test -p PROMOTE=${{ github.repository }}/frontend:test -p NAME=${{ github.event.repository.name }}
+            template_vars: ""
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_server: ${{ secrets.OC_SERVER }}
@@ -48,7 +48,9 @@ jobs:
       penetration_test: true
       repository: bcgov/nr-quickstart-typescript
       template_file: ${{ matrix.template_file }}
-      template_vars: ${{ matrix.template_vars }}
+      template_vars:
+        -p ZONE=test -p PROMOTE=${{ github.repository }}/${{ matrix.component }}:test
+        -p NAME=${{ github.event.repository.name }} ${{ matrix.template_vars }}
 
   deploys-prod:
     name: PROD Deployments
@@ -62,15 +64,15 @@ jobs:
           - component: database
             overwrite: false
             template_file: database/openshift.deploy.yml
-            template_vars: -p ZONE=prod -p NAME=${{ github.event.repository.name }}
+            template_vars: ""
           - component: backend
             overwrite: true
             template_file: backend/openshift.deploy.yml
-            template_vars: -p ZONE=prod -p PROMOTE=${{ github.repository }}/backend:test -p NAME=${{ github.event.repository.name }}
+            template_vars: ""
           - component: frontend
             overwrite: true
             template_file: frontend/openshift.deploy.yml
-            template_vars: -p ZONE=prod -p PROMOTE=${{ github.repository }}/frontend:test -p NAME=${{ github.event.repository.name }}
+            template_vars: ""
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_server: ${{ secrets.OC_SERVER }}
@@ -82,7 +84,9 @@ jobs:
       penetration_test: true
       repository: bcgov/nr-quickstart-typescript
       template_file: ${{ matrix.template_file }}
-      template_vars: ${{ matrix.template_vars }}
+      template_vars:
+        -p ZONE=prod -p PROMOTE=${{ github.repository }}/${{ matrix.component }}:prod
+        -p NAME=${{ github.event.repository.name }} ${{ matrix.template_vars }}
 
   image-promotions:
     name: Promote images to PROD
@@ -91,7 +95,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        component: [backend, frontend]
+        component: [backend, database, frontend]
     steps:
       - uses: shrink/actions-docker-registry-tag@v3
         with:

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -23,19 +23,23 @@ jobs:
     uses: ./.github/workflows/_deploy.yml
     strategy:
       matrix:
-        component: [backend, database, frontend]
+        component: [backend, database, frontend, init]
         include:
-          - component: database
-            overwrite: false
-            template_file: database/openshift.deploy.yml
-            template_vars: ""
           - component: backend
             overwrite: true
             template_file: backend/openshift.deploy.yml
             template_vars: ""
+          - component: database
+            overwrite: false
+            template_file: database/openshift.deploy.yml
+            template_vars: ""
           - component: frontend
             overwrite: true
             template_file: frontend/openshift.deploy.yml
+            template_vars: ""
+          - component: init
+            overwrite: false
+            template_file: common/openshift.init.yml
             template_vars: ""
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
@@ -59,19 +63,23 @@ jobs:
     uses: ./.github/workflows/_deploy.yml
     strategy:
       matrix:
-        component: [backend, database, frontend]
+        component: [backend, database, frontend, init]
         include:
-          - component: database
-            overwrite: false
-            template_file: database/openshift.deploy.yml
-            template_vars: ""
           - component: backend
             overwrite: true
             template_file: backend/openshift.deploy.yml
             template_vars: ""
+          - component: database
+            overwrite: false
+            template_file: database/openshift.deploy.yml
+            template_vars: ""
           - component: frontend
             overwrite: true
             template_file: frontend/openshift.deploy.yml
+            template_vars: ""
+          - component: init
+            overwrite: false
+            template_file: common/openshift.init.yml
             template_vars: ""
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -5,7 +5,7 @@ on:
     types:
       - closed
     paths-ignore:
-      - ".github/ISSUE_TEMPLATE/*"
+      - ".github/**"
       - "**.md"
 
 concurrency:
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        component: [backend, frontend]
+        component: [backend, database, frontend]
     steps:
       - uses: shrink/actions-docker-registry-tag@v3
         with:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -79,20 +79,24 @@ jobs:
     uses: ./.github/workflows/_deploy.yml
     strategy:
       matrix:
-        component: [backend, database, frontend]
+        component: [backend, database, frontend, init]
         include:
-          - component: database
-            overwrite: false
-            template_file: database/openshift.deploy.yml
-            template_vars: ""
           - component: backend
             overwrite: true
             template_file: backend/openshift.deploy.yml
             template_vars: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
+          - component: database
+            overwrite: false
+            template_file: database/openshift.deploy.yml
+            template_vars: ""
           - component: frontend
             overwrite: true
             template_file: frontend/openshift.deploy.yml
             template_vars: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
+          - component: init
+            overwrite: false
+            template_file: common/openshift.init.yml
+            template_vars: ""
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_server: ${{ secrets.OC_SERVER }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -36,10 +36,12 @@ jobs:
     uses: ./.github/workflows/_build.yml
     strategy:
       matrix:
-        component: [backend, frontend]
+        component: [backend, database, frontend]
         include:
           - component: backend
             triggers: ('backend/')
+          - component: database
+            triggers: ('database/')
           - component: frontend
             triggers: ('frontend/')
     secrets:
@@ -59,7 +61,7 @@ jobs:
     uses: ./.github/workflows/_build.yml
     strategy:
       matrix:
-        component: [backend, frontend]
+        component: [backend, database, frontend]
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
     with:
@@ -67,6 +69,44 @@ jobs:
       img_build: ${{ github.event.number }}
       img_fallback: test
       repository: bcgov/nr-quickstart-typescript
+
+  deploys:
+    name: Deploys
+    needs:
+      - builds
+    # If any of the prerequs created a build, then deploy
+    if: contains(needs.*.outputs.build, 'true')
+    uses: ./.github/workflows/_deploy.yml
+    strategy:
+      matrix:
+        component: [backend, database, frontend]
+        include:
+          - component: database
+            overwrite: false
+            template_file: database/openshift.deploy.yml
+            template_vars: ""
+          - component: backend
+            overwrite: true
+            template_file: backend/openshift.deploy.yml
+            template_vars: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
+          - component: frontend
+            overwrite: true
+            template_file: frontend/openshift.deploy.yml
+            template_vars: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
+    secrets:
+      oc_namespace: ${{ secrets.OC_NAMESPACE }}
+      oc_server: ${{ secrets.OC_SERVER }}
+      oc_token: ${{ secrets.OC_TOKEN }}
+    with:
+      component: ${{ matrix.component }}
+      overwrite: ${{ matrix.overwrite }}
+      repository: bcgov/nr-quickstart-typescript
+      penetration_test: false
+      template_file: ${{ matrix.template_file }}
+      template_vars:
+        -p ZONE=${{ github.event.number }} -p NAME=${{ github.event.repository.name }}
+        -p PROMOTE=${{ github.repository }}/${{ matrix.component }}:${{ github.event.number }}
+        ${{ matrix.template_vars }}
 
   tests:
     name: Unit Tests
@@ -90,47 +130,6 @@ jobs:
       test_cmd: |
         npm ci
         npm run test:cov
-
-  deploys:
-    name: Deploys
-    needs:
-      - builds
-    # If any of the prerequs created a build, then deploy
-    if: contains(needs.*.outputs.build, 'true')
-    uses: ./.github/workflows/_deploy.yml
-    strategy:
-      matrix:
-        component: [backend, database, frontend]
-        include:
-          - component: database
-            overwrite: false
-            template_file: database/openshift.deploy.yml
-            template_vars: -p ZONE=${{ github.event.number }} -p NAME=${{ github.event.repository.name }}
-          - component: backend
-            overwrite: true
-            template_file: backend/openshift.deploy.yml
-            template_vars:
-              -p ZONE=${{ github.event.number }} -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
-              -p PROMOTE=${{ github.repository }}/backend:${{ github.event.number }}
-              -p NAME=${{ github.event.repository.name }}
-          - component: frontend
-            overwrite: true
-            template_file: frontend/openshift.deploy.yml
-            template_vars:
-              -p ZONE=${{ github.event.number }} -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
-              -p PROMOTE=${{ github.repository }}/frontend:${{ github.event.number }}
-              -p NAME=${{ github.event.repository.name }}
-    secrets:
-      oc_namespace: ${{ secrets.OC_NAMESPACE }}
-      oc_server: ${{ secrets.OC_SERVER }}
-      oc_token: ${{ secrets.OC_TOKEN }}
-    with:
-      component: ${{ matrix.component }}
-      overwrite: ${{ matrix.overwrite }}
-      repository: bcgov/nr-quickstart-typescript
-      penetration_test: false
-      template_file: ${{ matrix.template_file }}
-      template_vars: ${{ matrix.template_vars }}
 
   # # Uncomment to view GitHub context object
   # # https://docs.github.com/en/actions/learn-github-actions/contexts


### PR DESCRIPTION
The new database deployment in nr-quickstart-typescript creates a container (postgres or postgis), so this repo needs to adjust.  This includes consuming the init template (secrets, network policies).

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-helpers-87-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-helpers-87-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-helpers/actions/workflows/merge-main.yml)