### PR TITLE
Pipeline overhaul bugs - prod tag and Dependabot permissions

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -85,7 +85,7 @@ jobs:
       repository: bcgov/nr-quickstart-typescript
       template_file: ${{ matrix.template_file }}
       template_vars:
-        -p ZONE=prod -p PROMOTE=${{ github.repository }}/${{ matrix.component }}:prod
+        -p ZONE=prod -p PROMOTE=${{ github.repository }}/${{ matrix.component }}:test
         -p NAME=${{ github.event.repository.name }} ${{ matrix.template_vars }}
 
   image-promotions:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -14,6 +14,8 @@ jobs:
       DOMAIN: apps.silver.devops.gov.bc.ca
       NAME: nr-quickstart-helpers
     runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
     steps:
       - uses: bcgov-nr/action-pr-description-add@v0.0.2
         with:


### PR DESCRIPTION
Two helpers have been replaced with Actions. Bugs:

- prod is deploying as prod before the tag has been applied
- PR greeting/commenter is failing from Dependabot PRs

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-helpers-101-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-helpers-101-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-helpers/actions/workflows/merge-main.yml)