### PR TITLE
More dependabot permissions (build)

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -44,6 +44,8 @@ jobs:
     # These builds don't have triggers and will fire every time
     name: Retags
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     strategy:
       matrix:
         package: [backend, database, frontend]
@@ -71,6 +73,8 @@ jobs:
     needs:
       - retags
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     strategy:
       matrix:
         package: [backend, database, frontend]


### PR DESCRIPTION
Dependabot PRs are failing for PR builds now.  This only happens on PRs created by and last touched by Dependabot, whish makes troubleshooting slow.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-quickstart-helpers-102-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://nr-quickstart-helpers-102-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-quickstart-helpers/actions/workflows/merge-main.yml)